### PR TITLE
allow logging in with an existing API token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 
 clean:
 	@go clean
-	@rm $(OUTPUT_FILE) -f
+	@rm -f $(OUTPUT_FILE)
 
 build:
 	@mkdir -p dist

--- a/command/meta.go
+++ b/command/meta.go
@@ -33,7 +33,7 @@ func (m *Meta) FatalError(v error) {
 
 // AskCredentials prompts for username and password
 func (m *Meta) AskCredentials() (string, string, error) {
-	username, err := m.UI.Ask("Username:")
+	username, err := m.UI.Ask("Username (use \"token\" if you're providing an API token as password):")
 	if err != nil {
 		return "", "", err
 	}

--- a/utils/gitlab.go
+++ b/utils/gitlab.go
@@ -67,6 +67,11 @@ func NewGitlabClient(gitlabLink string) (*GitlabClient, error) {
 
 // Authenticate authenticates against a Gitlab instance, storing the access_token
 func (c *GitlabClient) Authenticate(username, password string) error {
+	if username == "token" {
+		c.Token = password
+		return nil
+	}
+
 	c.Endpoint.Path = "oauth/token"
 
 	data := url.Values{


### PR DESCRIPTION
By providing `token` as username (otherwise normal login is used to try to generate a token)